### PR TITLE
python 2/3 compatible unicode

### DIFF
--- a/formulaic/auto_populate.py
+++ b/formulaic/auto_populate.py
@@ -1,5 +1,5 @@
 from raven.contrib.django.raven_compat.models import client as raven_client
-from six import iteritems
+from six import iteritems, u
 
 from formulaic.utils import state_from_zip, city_from_zip
 
@@ -45,7 +45,7 @@ def _attempt_state_or_city_from_zipcode(submission_kv, field_val, form_data):
             zipcode = value.strip()[:5]
         except AttributeError:
             raven_client.captureException()
-            zipcode = unicode(value).strip()[:5]
+            zipcode = u(value).strip()[:5]
         break
 
     if is_hidden_field and zipcode and not field_val:

--- a/formulaic/csv_export.py
+++ b/formulaic/csv_export.py
@@ -1,5 +1,6 @@
 import csv
 import pytz
+from six import u
 from tzlocal import get_localzone
 
 from formulaic import models, utils
@@ -27,5 +28,5 @@ def export_submissions_to_file(form, output_file):
             )
             row["date"] = date_created_aware.strftime('%m/%d/%Y %H:%M')
             row["source"] = submission.source
-            row_batch.append({k: unicode(v).encode('utf-8') for (k, v) in row.items()})
+            row_batch.append({k: u(v).encode('utf-8') for (k, v) in row.items()})
         writer.writerows(row_batch)

--- a/formulaic/fields.py
+++ b/formulaic/fields.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from django.forms.fields import CharField, ChoiceField, HiddenInput, MultiValueField, Select
 from django.forms.utils import ErrorList
 from nameparser import HumanName
-from six import iteritems
+from six import iteritems, text_type
 
 from formulaic.widgets import GroupedChoiceWidget
 
@@ -28,7 +28,7 @@ class FullNameField(CharField):
 class GroupedChoiceField(MultiValueField):
     def __init__(self, groups={}, initial=None, field_class=ChoiceField, widget_class=Select, widget_attrs={}, *args, **kwargs):
         # create hidden_field for tracking selected field
-        data_initial = initial if isinstance(initial, unicode) else json.dumps(initial)
+        data_initial = initial if isinstance(initial, text_type) else json.dumps(initial)
         group_id_field = CharField(widget=HiddenInput(attrs={"data-initial": data_initial}), initial=None)
 
         fields = [group_id_field]

--- a/formulaic/models.py
+++ b/formulaic/models.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models, transaction
 from django.forms import fields, widgets
 from django.utils.functional import cached_property
-from six import iteritems
+from six import iteritems, python_2_unicode_compatible, u
 
 from formulaic import fields as custom_fields
 from formulaic.auto_populate import attempt_kv_auto_populate
@@ -14,6 +14,7 @@ from formulaic.signals import submission_complete
 from formulaic.validators import validate_mixed_content
 
 
+@python_2_unicode_compatible
 class Form(models.Model):
     BASE_COLUMN_HEADERS = ['date', 'source']
     name = models.CharField(max_length=500)
@@ -89,9 +90,9 @@ class Form(models.Model):
     def autocomplete_search_fields():
         return ("id__iexact", "name__icontains", "slug__icontains", )
 
-    def __unicode__(self):
+    def __str__(self):
         if self.archived:
-            return u"{} (archived)".format(self.name)
+            return u("{} (archived)".format(self.name))
         else:
             return self.name
 
@@ -99,6 +100,7 @@ class Form(models.Model):
         ordering = ('archived', 'name',)
 
 
+@python_2_unicode_compatible
 class PrivacyPolicy(models.Model):
     """
     Provides an editable list of privacy policies which can be selected
@@ -115,10 +117,11 @@ class PrivacyPolicy(models.Model):
     class Meta:
         verbose_name_plural = "Privacy policies"
 
-    def __unicode__(self):
-        return unicode(self.name)
+    def __str__(self):
+        return self.name
 
 
+@python_2_unicode_compatible
 class OptionList(models.Model):
     """
     Collection of options for use in selects, checkbox lists,
@@ -140,10 +143,11 @@ class OptionList(models.Model):
         """
         return len(self.cached_groups) > 0
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class Option(models.Model):
     """
     An individual selectable option, represented as a member
@@ -156,13 +160,14 @@ class Option(models.Model):
 
     list = models.ForeignKey(OptionList, on_delete=models.CASCADE)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     class Meta:
         ordering = ('position',)
 
 
+@python_2_unicode_compatible
 class OptionGroup(models.Model):
     """
     A group of Options in an OptionList.  OptionGroups provide
@@ -182,13 +187,14 @@ class OptionGroup(models.Model):
     def cached_options(self):
         return self.options.all()
 
-    def __unicode__(self):
+    def __str__(self):
         return "{}:{}".format(self.list.name, self.name)
 
     class Meta:
         ordering = ('position',)
 
 
+@python_2_unicode_compatible
 class Field(models.Model):
     # TODO: look into changing these
     TYPE_SELECT = "select"
@@ -240,7 +246,7 @@ class Field(models.Model):
         # might need to support duplicates across multiple pages
         unique_together = ("form", "slug")
 
-    def __unicode__(self):
+    def __str__(self):
         return self.data_name
 
     def save(self, **kwargs):
@@ -507,6 +513,7 @@ class ChoiceField(Field):
         super(ChoiceField, self).save(**kwargs)
 
 
+@python_2_unicode_compatible
 class RuleResult(models.Model):
     ACTION_SHOW = 'show'
     ACTION_HIDE = 'hide'
@@ -531,8 +538,8 @@ class RuleResult(models.Model):
         'OptionGroup', on_delete=models.PROTECT, blank=True, null=True
     )
 
-    def __unicode__(self):
-        return unicode("{}: '{}' field '{}' if rule '{}' is true".format(
+    def __str__(self):
+        return u("{}: '{}' field '{}' if rule '{}' is true".format(
             self.id,
             self.action,
             self.field_id,
@@ -540,6 +547,7 @@ class RuleResult(models.Model):
         ))
 
 
+@python_2_unicode_compatible
 class Rule(models.Model):
     OPERATOR_AND = 'and'
     OPERATOR_OR = 'or'
@@ -553,13 +561,14 @@ class Rule(models.Model):
     operator = models.CharField(max_length=3, choices=OPERATOR_CHOICES)
     position = models.IntegerField()
 
-    def __unicode__(self):
-        return unicode('{}: position "{}"'.format(self.id, self.position))
+    def __str__(self):
+        return u('{}: position "{}"'.format(self.id, self.position))
 
     class Meta:
         ordering = ('position',)
 
 
+@python_2_unicode_compatible
 class RuleCondition(models.Model):
     OPERATOR_IS = 'is'
     OPERATOR_IS_NOT = 'is_not'
@@ -603,8 +612,8 @@ class RuleCondition(models.Model):
     def value(self, value):
         self.value_string = json.dumps(value)
 
-    def __unicode__(self):
-        return unicode('{}: field "{}" {} ______'.format(
+    def __str__(self):
+        return u('{}: field "{}" {} ______'.format(
             self.id,
             self.field_id,
             self.operator
@@ -614,6 +623,7 @@ class RuleCondition(models.Model):
         ordering = ('position',)
 
 
+@python_2_unicode_compatible
 class DisplayCondition(models.Model):
     IS = "is"
     IS_NOT = "is_not"
@@ -644,7 +654,7 @@ class DisplayCondition(models.Model):
             # TODO: setup default values which could match the DisplayCondition values
             return False
 
-    def __unicode__(self):
+    def __str__(self):
         return "Display field #{} if field #{} {} {}".format(
             self.affected_field_id,
             self.watched_field_id,
@@ -691,6 +701,7 @@ class Submission(models.Model):
         self.metadata_serialized = json.dumps(value)
 
 
+@python_2_unicode_compatible
 class SubmissionKeyValue(models.Model):
     submission = models.ForeignKey(
         Submission, on_delete=models.CASCADE, related_name="values"
@@ -734,5 +745,5 @@ class SubmissionKeyValue(models.Model):
 
         return value
 
-    def __unicode__(self):
+    def __str__(self):
         return "{}:{}".format(self.key, self.value)

--- a/formulaic/serializers.py
+++ b/formulaic/serializers.py
@@ -1,4 +1,5 @@
 import pytz
+import six
 from tzlocal import get_localzone
 
 from formulaic import models
@@ -46,7 +47,7 @@ class HiddenFieldSerializer(serializers.ModelSerializer):
 class JsonField(serializers.Field):
 
     def to_internal_value(self, data):
-        if isinstance(data, basestring) or isinstance(data, dict) or isinstance(data, list):
+        if isinstance(data, six.text_type) or isinstance(data, dict) or isinstance(data, list):
             return data
         else:
             msg = self.error_messages['invalid']
@@ -59,7 +60,7 @@ class JsonField(serializers.Field):
 class DefaultOptionField(serializers.Field):
 
     def to_internal_value(self, data):
-        if isinstance(data, basestring):
+        if isinstance(data, six.text_type):
             return data
         else:
             msg = self.error_messages['invalid']


### PR DESCRIPTION
* replaced `__unicode__()` with `__str__()`. classes have been decorated with
  `six.python_2_unicode_compatible` to retain py2 compatibility
* replaced calls to `unicode()` with `six.u()`
* replaced references to `basestring` or `unicode` types with `six.text_type`