### PR TITLE
Eliminate Django deprecation warnings

### DIFF
--- a/formulaic/admin.py
+++ b/formulaic/admin.py
@@ -1,7 +1,10 @@
 import json
 
 from django import forms
-from django.conf.urls import url
+try:
+    from django.urls import re_path
+except ImportError:
+    from django.conf.urls import url as re_path
 from django.contrib import admin
 from django.core.exceptions import PermissionDenied
 try:
@@ -133,9 +136,9 @@ class FormAdmin(admin.ModelAdmin):
         url_patterns = super(FormAdmin, self).get_urls()
 
         return [
-            url(r'^([0-9]+)/archive/$', self.archive_view, name="formulaic_form_archive"),
-            url(r'^([0-9]+)/unarchive/$', self.unarchive_view, name="formulaic_form_unarchive"),
-            url(r'^([0-9]+)/.+$', self.change_view),
+            re_path(r'^([0-9]+)/archive/$', self.archive_view, name="formulaic_form_archive"),
+            re_path(r'^([0-9]+)/unarchive/$', self.unarchive_view, name="formulaic_form_unarchive"),
+            re_path(r'^([0-9]+)/.+$', self.change_view),
         ] + url_patterns
 
     def change_view(self, request, object_id, form_url='', extra_context=None):

--- a/formulaic/signals.py
+++ b/formulaic/signals.py
@@ -5,4 +5,4 @@ from django.dispatch import Signal
 Submissions are saved in stages.  This is fired after
 all steps are complete, and the Submission is complete.
 """
-submission_complete = Signal(providing_args=["submission", "form", ])
+submission_complete = Signal()

--- a/formulaic/urls.py
+++ b/formulaic/urls.py
@@ -1,6 +1,11 @@
-from django.conf.urls import url, include
-from rest_framework import routers
+try:
+    # django 3+
+    from django.urls import include, re_path
+except ImportError:
+    # django 1 and 2
+    from django.conf.urls import include, url as re_path
 
+from rest_framework import routers
 from formulaic import views
 
 router = routers.SimpleRouter()
@@ -20,7 +25,7 @@ router.register(r'ruleresults', views.RuleResultViewset)
 router.register(r'submissions', views.SubmissionViewset)
 
 urlpatterns = [
-    url(r'^api/submissionsources/$', views.SubmissionSourceView.as_view()),
-    url(r'^api/', include(router.urls)),
-    url(r'^download/submissions/$', views.download_submissions),
+    re_path(r'^api/submissionsources/$', views.SubmissionSourceView.as_view()),
+    re_path(r'^api/', include(router.urls)),
+    re_path(r'^download/submissions/$', views.download_submissions),
 ]


### PR DESCRIPTION
* Django 4 will remove `django.conf.urls.url()` in favor of
  `django.urls.re_path()`. Formulaic now attempts to import the latter
  and falls back to the older version on `ImportError`.
* Removed the `providing_args` argument to the `submission_complete`
  signal. This argument is solely for documentation and has been
  deprecated.