### PR TITLE
VIR-152 Handling deleted Field FKs better

### DIFF
--- a/formulaic/models.py
+++ b/formulaic/models.py
@@ -743,7 +743,7 @@ class SubmissionKeyValue(models.Model):
 
     @value.setter
     def value(self, value):
-        if self.field.subtype_is(TextField.SUBTYPE_TEXTAREA):
+        if self.field and self.field.subtype_is(TextField.SUBTYPE_TEXTAREA):
             self.value_textfield = value
             self.value_charfield = None
         else:
@@ -755,7 +755,7 @@ class SubmissionKeyValue(models.Model):
         value = self.value
 
         # replace ids with text values
-        if value and self.field.subtype_in(ChoiceField.SUBTYPES.keys()):
+        if value and self.field and self.field.subtype_in(ChoiceField.SUBTYPES.keys()):
             # convert to list for query
             if not isinstance(value, list):
                 value = [value]


### PR DESCRIPTION
Prior to this PR, if a form was submitted, and then the field was deleted, and then re added, the submission export would fail.

This PR hopes to address this situation. Additionally, some queries can be saved by calling `select_related` on the `values` prefetch when exporting.