### PR TITLE
VIR-145: Adding prefetched_custom_data method to Submission queryset 

### DIFF
--- a/formulaic/models.py
+++ b/formulaic/models.py
@@ -1,6 +1,7 @@
 import json
 
 from ckeditor.fields import RichTextField
+import django
 from django.contrib.contenttypes.models import ContentType
 from django.db import models, transaction
 from django.db.models import Max
@@ -677,7 +678,87 @@ class DisplayCondition(models.Model):
         )
 
 
+class SubmissionQuerySet(models.QuerySet):
+
+    def __init__(
+        self,
+        *args,
+        should_prefetch_custom_data=False,
+        **kwargs,
+    ):
+        """Overloading __init__ to allow for lazy prefetching of prefetch_custom_data"""
+        super().__init__(*args, **kwargs)
+        self._should_prefetch_custom_data = should_prefetch_custom_data
+        self._prefetch_custom_data_done = False
+
+    def _clone(self):
+        """Overloading _clone to allow for lazy prefetching of prefetch_custom_data"""
+        clone = super()._clone()
+        clone._should_prefetch_custom_data = self._should_prefetch_custom_data
+
+        return clone
+
+    def _fetch_all(self):
+        """Overloading _fetch_all to allow for lazy prefetching of prefetch_custom_data"""
+
+        r = super()._fetch_all()
+        if self._should_prefetch_custom_data and not self._prefetch_custom_data_done:
+            self._execute_prefetch_custom_data()
+
+        return r
+
+    def _execute_prefetch_custom_data(self):
+        """Performs the prefetch on the custom data in bulk"""
+        relevant_choices = (
+            SubmissionKeyValue.objects
+            .filter(submission__in=self, field__subtype__in=ChoiceField.SUBTYPES.keys())
+            .distinct("value_charfield")
+            .values_list("value_charfield", flat=True)
+        )
+
+        relevant_choices = [json.loads(choice) for choice in relevant_choices]
+        options = Option.objects.filter(id__in=relevant_choices).values_list("id", "name")
+        options_lookup = dict(options)
+
+        forms_by_id = dict()
+
+        # We need to assign forms here to the python objects. Without this step,
+        # we would create multiple python objects for the same form contained in
+        # the database. By reassigning the form here we cache results onto a
+        # single python object. It should be noted that in practice, there will
+        # likely only be one form, but this supports submissions across
+        # different forms.
+        for submission in self._result_cache:
+            if submission.form_id in forms_by_id:
+                submission.form = forms_by_id[submission.form_id]
+            else:
+                forms_by_id[submission.form_id] = submission.form
+
+            # Actually constructing the custom data and storing it.
+            submission._get_custom_data_with_option_lookup(options_lookup)
+
+    def prefetch_custom_data(self):
+        """Returns a list with all of the custom data included."""
+
+        if django.get_version() < "2.0.0":
+            raise NotImplementedError("Currently only available for django >2.0.0")
+
+        self._should_prefetch_custom_data = True
+        return self.select_related("form")
+
+
+class SubmissionManager(models.Manager):
+    def get_queryset(self):
+        return SubmissionQuerySet(self.model, using=self._db)
+
+    def prefetch_custom_data(self):
+        return self.get_queryset().prefetch_custom_data()
+
+
 class Submission(models.Model):
+
+    objects = SubmissionManager()
+
     form = models.ForeignKey(Form, on_delete=models.PROTECT)
     date_created = models.DateTimeField()
 
@@ -705,6 +786,37 @@ class Submission(models.Model):
                 data[key_value.key] = key_value.output_value
 
         return data
+
+    _prefetched_custom_data_cache = None
+
+    @property
+    def prefetched_custom_data(self):
+        """Retrieves the custom data that was prefetched by the
+        "prefetch_custom_data" queryset method.
+        """
+
+        if not self._prefetched_custom_data_cache:
+            self._prefetched_custom_data_cache = self.custom_data
+        return self._prefetched_custom_data_cache
+
+    def _get_custom_data_with_option_lookup(self, options_lookup):
+        """Similar output to "custom_data" property, however this allows for an
+        options_lookup and importantly calls the _output_value_with_options_lookup
+        method on the SubmissionKeyValue objects. Calling this with the lookup
+        allows for much more efficient bulk exports.
+         """
+        if not self._prefetched_custom_data_cache:
+
+            column_headers = self.form.column_headers
+            data = {}
+
+            for key_value in self.values.all():
+                if key_value.key in column_headers:
+                    data[key_value.key] = key_value._output_value_with_options_lookup(options_lookup)
+
+            self._bulk_custom_data_cache = data
+
+        return self._bulk_custom_data_cache
 
     metadata_serialized = models.TextField(
         help_text="Serialized JSON object storing arbitrary submission-related metadata"
@@ -762,6 +874,27 @@ class SubmissionKeyValue(models.Model):
 
             selected_options = Option.objects.filter(id__in=value).values_list('name', flat=True)
 
+            value = ",".join(selected_options)
+
+        return value
+
+    def _output_value_with_options_lookup(self, options_lookup):
+        """Mirrors "output_value", but with an option_lookup dictionary. This
+        dictionary avoids looking up the options in the database. This is useful for when
+        exporting multiple submissions of the same form, as the Options being
+        looked up are almost always the same.
+
+        options_lookup is a dictionary with "values" as keys and "names" as values
+        """
+        value = self.value
+
+        # replace ids with text values
+        if value and self.field and self.field.subtype_in(ChoiceField.SUBTYPES.keys()):
+            # convert to list for query
+            if not isinstance(value, list):
+                value = [value]
+
+            selected_options = [options_lookup.get(json.loads(v)) for v in value]
             value = ",".join(selected_options)
 
         return value

--- a/formulaic/models.py
+++ b/formulaic/models.py
@@ -680,23 +680,8 @@ class DisplayCondition(models.Model):
 
 class SubmissionQuerySet(models.QuerySet):
 
-    def __init__(
-        self,
-        *args,
-        should_prefetch_custom_data=False,
-        **kwargs,
-    ):
-        """Overloading __init__ to allow for lazy prefetching of prefetch_custom_data"""
-        super().__init__(*args, **kwargs)
-        self._should_prefetch_custom_data = should_prefetch_custom_data
-        self._prefetch_custom_data_done = False
-
-    def _clone(self):
-        """Overloading _clone to allow for lazy prefetching of prefetch_custom_data"""
-        clone = super()._clone()
-        clone._should_prefetch_custom_data = self._should_prefetch_custom_data
-
-        return clone
+    _should_prefetch_custom_data = False
+    _prefetch_custom_data_done = False
 
     def _fetch_all(self):
         """Overloading _fetch_all to allow for lazy prefetching of prefetch_custom_data"""


### PR DESCRIPTION
## Motivation
One of big gap in Formulaic is the speed at which exports can be made based on submissions. This is mostly due to the fact that when retrieving a value of a `SubmissionKeyValue` it is possible that it will need to look up the the set of Options that the object could be cast too. The construction of this makes it pretty impossible for library users to optimize the retrieval of data.

When doing an export, typically there is a pretty limited set of options that a form is actually delivering, and it is not unreasonable to look up those options, store them in a python dictionary, and retrieve them as needed. Ultimately, wouldn't it be nice to just have a function that just collects all the "custom_data" at once with minimal querying?

## Solution
I should preface this with that I did not add support to Django 1.x, and only tested it with Django 3.x. I had a peak at the django source code, and I _believe_ version 2.x should be supported.

A new queryset method was written to "prefetch" the cached data. It hooks into the built in  `_fetch_all` method to allow for lazy evaluation. This will mean that the method should be commutative. i.e. 
```
Submission.objects.filter(form_id=1).prefetched_custom_data()
```
is equivalent to:
```
Submission.objects.prefetched_custom_data().filter(form_id=1)
```

## Example usage:
Both of these snippets are functionally equivalent, however the number of database queries is drastically reduced in the second.
#### Old way:
```
my_form = Form.objects.first()
my_submissions = Submission.objects.filter(form=my_form)
for submission in submissions:
    print(submission.custom_data)
```
#### New way:
```
my_form = Form.objects.first()
my_submissions = Submission.objects.filter(form=my_form).prefetched_custom_data()
for submission in submissions:
    print(submission.prefetched_custom_data)
```