### PR TITLE
VIR-316 Do not invalidate integer inputs.

### DIFF
--- a/formulaic/serializers.py
+++ b/formulaic/serializers.py
@@ -47,10 +47,11 @@ class HiddenFieldSerializer(serializers.ModelSerializer):
 class JsonField(serializers.Field):
 
     def to_internal_value(self, data):
-        if isinstance(data, six.text_type) or isinstance(data, dict) or isinstance(data, list):
+        types = [int, six.text_type, dict, list]
+        if any(map(lambda t: isinstance(data, t), types)):
             return data
         else:
-            msg = self.error_messages['invalid']
+            msg = self.error_messages.get('invalid', "unknown error")
             raise serializers.ValidationError(msg)
 
     def to_representation(self, obj):


### PR DESCRIPTION
No idea why this started happening, or what changed. 

When a trying to convert the form input for a FK when serializing rules,  it looks like they were previously only being interpreted as a string, or a list, or a dict, or something other than an integer. Now they are integers. This lead to the inability to save most forms from the admin.

This small PR permits a form value to be an integer. 