### PR TITLE
VIR-355 Remove RuleResult and RuleCondition when deleting fields 

### DIFF
--- a/formulaic/views.py
+++ b/formulaic/views.py
@@ -164,8 +164,16 @@ class FieldViewset(viewsets.ModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ('form',)
 
+    def destroy(self, request, *args, **kwargs):
+        """Clean up any rules that may be associated with the object."""
+        instance = self.get_object()
+        instance.ruleresult_set.all().delete()
+        instance.rulecondition_set.all().delete()
 
-class TextFieldViewset(viewsets.ModelViewSet):
+        return super().destroy(request, *args, **kwargs)
+
+
+class TextFieldViewset(FieldViewset):
     permission_classes = (
         CustomDjangoModelPermissions,
     )
@@ -179,7 +187,7 @@ class TextFieldViewset(viewsets.ModelViewSet):
     filterset_fields = ('form',)
 
 
-class ChoiceFieldViewset(viewsets.ModelViewSet):
+class ChoiceFieldViewset(FieldViewset):
     permission_classes = (
         CustomDjangoModelPermissions,
     )
@@ -193,7 +201,7 @@ class ChoiceFieldViewset(viewsets.ModelViewSet):
     filterset_fields = ('form',)
 
 
-class BooleanFieldViewset(viewsets.ModelViewSet):
+class BooleanFieldViewset(FieldViewset):
     permission_classes = (
         CustomDjangoModelPermissions,
     )
@@ -207,7 +215,7 @@ class BooleanFieldViewset(viewsets.ModelViewSet):
     filterset_fields = ('form',)
 
 
-class HiddenFieldViewset(viewsets.ModelViewSet):
+class HiddenFieldViewset(FieldViewset):
     permission_classes = (
         CustomDjangoModelPermissions,
     )

--- a/formulaic/views.py
+++ b/formulaic/views.py
@@ -165,7 +165,15 @@ class FieldViewset(viewsets.ModelViewSet):
     filterset_fields = ('form',)
 
     def destroy(self, request, *args, **kwargs):
-        """Clean up any rules that may be associated with the object."""
+        """Clean up any rules that may be associated with the object.
+
+        # todo
+        This is intended to only be a temporary change to help alleviate
+        frustrations around not being able to delete fields. The ideal solution
+        would be to display to the user why they cannot delete a particular field.
+        At that point we can confirm the blanket delete (what this function is doing)
+        or help guide the user to carefully remove the ruleresults and ruleconditions.
+        """
         instance = self.get_object()
         instance.ruleresult_set.all().delete()
         instance.rulecondition_set.all().delete()


### PR DESCRIPTION
Users are  frustrated by not being able to delete fields that have rules associated with them due to the protected foreign key. 

We also do not do a particularly good job of informing users _why_ they can't delete them. This will hopefully be a consideration when designing the new react based frontend. However that is a little while off. 

I didn't want to remove the protected FK, as I do believe it has merit. The main problem is the interface not telling users why it can't be deleted. I anticipate that this is a "temporary" fix, and can hopefully be removed once we have a better user interface.