### PR TITLE
VIR-490 Radioselect no longer displays default text as an option.

### DIFF
--- a/formulaic/models.py
+++ b/formulaic/models.py
@@ -430,6 +430,13 @@ class ChoiceField(Field):
 
     @property
     def needs_default_text(self):
+
+        # Radio selects are a little special, in that they are multi selects,
+        # but do not have multiple options. Having a default option does not
+        # make sense.
+        if self.subtype == self.SUBTYPE_RADIOSELECT:
+            return False
+
         return not self.supports_multiple_values and not self.default_option
 
     @property


### PR DESCRIPTION
While working on VIR-490 in Virtuoso, I learned as a quirk of radio selects, it makes sense to not have a default option. Drop down menus it does make sense, but it looks quite strange to have a radio select option for the invalid default option.

e.g. 
<img width="707" alt="Screenshot 2022-12-14 at 3 40 07 PM" src="https://user-images.githubusercontent.com/3658545/207709229-61953242-0491-427a-8681-827abc4c66e2.png">

After this change, if their is no default selected, then it will not auto add one.
<img width="646" alt="Screenshot 2022-12-14 at 3 41 52 PM" src="https://user-images.githubusercontent.com/3658545/207709494-fecd252e-1244-454e-bc66-a8677eea7c6e.png">

