### PR TITLE
VIR-575 Allowing all versions of python 3.9.x to work.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 [options]
 include_package_data = true
 packages = find:
-python_requires = >=2.7, <=3.9
+python_requires = >=2.7, <3.10
 install_requires =
     Django >= 1.8
     django-admin-ordering==0.13.1


### PR DESCRIPTION
Right now, the maximum version of python we allow is 3.9.0. This is pretty crippling. This PR allows for up to 3.9.x to work.