### PR TITLE
VIR-916 Default to raw value string if no option found.

### DIFF
--- a/formulaic/models.py
+++ b/formulaic/models.py
@@ -953,7 +953,7 @@ class SubmissionKeyValue(models.Model):
             if not isinstance(value, list):
                 value = [value]
 
-            selected_options = [options_lookup.get(json.loads(v)) for v in value]
+            selected_options = [options_lookup.get(json.loads(v), str(v)) for v in value]
             return ",".join(selected_options)
 
         return self.output_value


### PR DESCRIPTION
Recently Virtuoso removed a newsletter option. This leads to an issue when exporting the value, as it when it tries to map a value in the database to the option it returns None. This _wouldn't_ be too much of a problem, if not for the fact that we immediately try to do string concatenation on it.

 Here, we replace the `None` value with a string representation of the raw value. For choice fields, this will sometimes end up being the id of a foreign key. It's not a perfect solution, but it's the best I think we can offer.

