### PR TITLE
VIR-1437 Correctly test for boolean field.

### DIFF
--- a/formulaic/rules.py
+++ b/formulaic/rules.py
@@ -62,8 +62,10 @@ class Field(object):
         self._visible = new_field_status.visible
 
     def has_value(self, value):
-        from django.forms import CheckboxInput
-        if type(self.form_field) is CheckboxInput:
+
+        from django.forms import CheckboxInput, BooleanField
+        # todo, I'm pretty sure CheckboxInput is not correct here.
+        if type(self.form_field) is CheckboxInput or isinstance(self.form_field, BooleanField):
             return self.value
         elif type(self.value) is list:
             return value in self.value


### PR DESCRIPTION
This is a doozy. 

Basically, when the backend was doing tests to see if a field was required or not (for form validation) it was incorrectly performing the test for checkbox fields. 

In short, the type of `self.form_field` is `BooleanField` and not `CheckboxInput`. I'm a little stumped how this ever really worked, may it does in older versions of Django? I dunno. I'm a little scared to pull out the `CheckboxInput` check right now, as I really just need this fixed to go live. 

The old behaviour would always go into the last condition, where it would perform `self.value == value`. Here, `self.value` is going to be `True` or `False`. `value` for a checkbox field is set to `None`. Resulting in the value always being `False`.