### PR TITLE
VIR-1569 Make `css_class` accessible to templates

### DIFF
--- a/example_project/templates/registration.html
+++ b/example_project/templates/registration.html
@@ -22,7 +22,7 @@
               {% for field in form.visible_fields %}
                 {% with field_type=field|widget_type %}
             
-                <div class="forms-field field-wrapper form-group {{ field.field.widget|formulaic_field_classes }}
+                <div class="forms-field field-wrapper form-group {{ field.field.wrapper_class }}
                             {% if field.errors %} field-error formulaic-error {% endif %}">
                   <label class="forms-field-label" for="{{ field.id_for_label }}">
                     {{ field.label|safe }} {% if field.field.required %}<span class="forms-required-label">*</span>{% endif %}

--- a/formulaic/forms.py
+++ b/formulaic/forms.py
@@ -51,10 +51,14 @@ class CustomForm(forms.Form):
             else:
                 specific_field = field.get_specific_field()
 
+            field_widget_attrs = widget_attrs.copy()
+
             self.fields[field.slug] = specific_field.get_implementation(
-                widget_attrs=widget_attrs
+                widget_attrs=field_widget_attrs
             )
 
+            # Assign an attribute on to the field to allow for access to the model fields css_class
+            self.fields[field.slug].wrapper_class = field.css_class
             self.field_slugs_by_id[field.id] = field.slug
 
         # Add rules to form


### PR DESCRIPTION
Setting the `css_class` to an attribute on the form class for access by the templates.

This isn't the most elegant solution, but I don't have tons of time to refine the Formulaic interface when it comes to customizing fields. I don't want to completely break the interface and example code right now.

This gets us across the line for current work.