### PR TITLE
VIR-1396 Phone number to python fix.=

### DIFF
--- a/example_project/templates/registration.html
+++ b/example_project/templates/registration.html
@@ -22,7 +22,7 @@
               {% for field in form.visible_fields %}
                 {% with field_type=field|widget_type %}
             
-                <div class="forms-field field-wrapper form-group {{ field.field.wrapper_class }}
+                <div class="forms-field field-wrapper form-group {{ field.field.widget|formulaic_field_classes }} {{ field.field.wrapper_class|default_if_none:"" }}
                             {% if field.errors %} field-error formulaic-error {% endif %}">
                   <label class="forms-field-label" for="{{ field.id_for_label }}">
                     {{ field.label|safe }} {% if field.field.required %}<span class="forms-required-label">*</span>{% endif %}

--- a/formulaic/widgets.py
+++ b/formulaic/widgets.py
@@ -45,7 +45,7 @@ class PhoneInput(TextInput):
             # to full_number
             full_number += formatted_number[formatted_number.find(ext_pre):]
 
-        return full_number
+        return full_number or formatted_number
 
     class Media:
         js = (


### PR DESCRIPTION
Minor phone number fix to help with invalid input from the frontend.

If the frontend widget does not provide the `full_phone` field we treat it as being blank. This is a problem for when we have an optional field, as all validation fails to trigger.

This was largely masked by a poor implementation of the frontend code.