### PR TITLE
VIR-1396 Use jQuery to set the phone number after unblur

### DIFF
--- a/formulaic/static/formulaic/js/phoneNumber.js
+++ b/formulaic/static/formulaic/js/phoneNumber.js
@@ -33,10 +33,10 @@ $(document).ready(function () {
                  let extension = iti.getExtension()
                  if (extension){
                      let formattedNumber = iti.getNumber() + phoneElement.getAttribute("extensionPrefix") + iti.getExtension();
-                     iti.setNumber(formattedNumber);
+                     $(iti.hiddenInput).attr("value", formattedNumber);
                  }
                  else {
-                     iti.setNumber(iti.getNumber());
+                     $(iti.hiddenInput).attr("value", iti.getNumber());
                  }
              }
         });


### PR DESCRIPTION
Minor phone number fix. The `iti.setNumber` function seems to be unreliable. This PR changes it to use jQuery where we can see what's going on a little better. 